### PR TITLE
[TEST #37]: Username 중복 확인(Validation) API 성능 테스트

### DIFF
--- a/server/src/main/java/com/example/server/global/test/data/BulkUserInsert.java
+++ b/server/src/main/java/com/example/server/global/test/data/BulkUserInsert.java
@@ -1,0 +1,110 @@
+package com.example.server.global.test.data;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+public class BulkUserInsert {
+
+    private static String url = "jdbc:mysql://localhost:3306/plog?rewriteBatchedStatements=true&useSSL=false";
+    private static String dbUsername = "root";
+    private static String dbPassword = "password";
+
+    private static final List<String> FIRST_NAMES = List.of(
+            "alex", "john", "emma", "mina", "kai", "olivia", "ethan", "noah", "liam", "sophia",
+            "mason", "isabella", "jacob", "mia", "william", "ava", "james", "charlotte", "benjamin", "amelia",
+            "logan", "harper", "elijah", "evelyn", "lucas", "abigail", "oliver", "emily", "henry", "ella",
+            "sebastian", "scarlett", "jack", "grace", "samuel", "chloe", "daniel", "victoria", "matthew", "lily",
+            "aiden", "hannah", "jayden", "layla", "gabriel", "zoe", "ryan", "nora", "caleb", "riley",
+            "isaac", "aria", "david", "camila", "nicholas", "penelope", "andrew", "lillian", "hunter", "bella",
+            "owen", "aubrey", "christopher", "hannah", "jeremiah", "addison", "cameron", "ella", "julian", "stella",
+            "eli", "natalie", "joseph", "zoey", "leonardo", "hazel", "joshua", "brooklyn", "jackson", "scarlett",
+            "ryder", "victoria", "grayson", "madison", "hunter", "skylar", "julian", "paisley", "adam", "aria",
+            "carter", "ellie", "nathan", "audrey", "christian", "samantha", "jonathan", "claire", "dominic", "piper"
+    );
+
+    private static final List<String> LAST_NAMES = List.of(
+            "kim", "lee", "park", "choi", "cho", "kang", "yun", "han", "jung", "jang",
+            "smith", "johnson", "williams", "brown", "jones", "miller", "davis", "garcia", "rodriguez", "wilson",
+            "martinez", "anderson", "taylor", "thomas", "hernandez", "moore", "martin", "jackson", "thompson", "white",
+            "lopez", "leeuw", "clark", "walker", "hall", "allen", "young", "king", "wright", "hill",
+            "scott", "green", "adams", "baker", "gonzalez", "nelson", "carter", "mitchell", "perez", "roberts",
+            "turner", "phillips", "campbell", "parker", "evans", "edwards", "collins", "stewart", "sanchez", "morris",
+            "rogers", "reed", "cook", "morgan", "bell", "murphy", "bailey", "rivera", "cooper", "richardson",
+            "cox", "howard", "ward", "torres", "peterson", "gray", "ramirez", "james", "watson", "brooks",
+            "kelly", "sanders", "price", "bennett", "wood", "barnes", "ross", "henderson", "coleman", "jenkins",
+            "perry", "powell", "long", "patterson", "hughes", "flores", "washington", "butler", "simmons", "foster"
+    );
+
+    private static final String INSERT_SQL =
+            "INSERT IGNORE INTO user (username, email, oauth_provider, oauth_id, created_at, last_modified_at, created_by, last_modified_by) VALUES (?, ?, ?, ?, now(), now(), 'system', 'system')";
+
+    public static void main(String[] args) throws SQLException {
+        final int TARGET = 10; // 건수
+        final int BATCH_SIZE = 1000;
+
+        try (Connection conn =  DriverManager.getConnection(url, dbUsername, dbPassword)) {
+            conn.setAutoCommit(false);
+
+            try (PreparedStatement ps = conn.prepareStatement(INSERT_SQL)) {
+
+                long start = System.currentTimeMillis();
+
+                int firstSize = FIRST_NAMES.size();
+                int lastSize = LAST_NAMES.size();
+
+                for (int i = 0; i < TARGET; i++) {
+
+                    // 순차적으로 first, last 선택
+                    String first = FIRST_NAMES.get(i % firstSize);
+                    String last = LAST_NAMES.get((i / firstSize) % lastSize);
+
+                    // username base 만들기
+                    String base = first + last;
+
+                    // 숫자 공간 확보
+                    int number = (i % 999) + 1; // 001~999
+                    String numberStr = String.format("%03d", number);
+
+                    // _ 위치 계산: 1 ~ (base.length - 1) 순환
+                    int underscorePos = (i % (base.length() - 1)) + 1;
+
+                    // username 만들기
+                    String username = base.substring(0, underscorePos) + "_" + base.substring(underscorePos);
+                    // 숫자 추가, 15자 초과 시 base 자르기
+                    if (username.length() + 3 > 15) {
+                        int allowedBaseLength = 15 - 3 - 1; // 3자리 숫자 + underscore
+                        if (allowedBaseLength < underscorePos) {
+                            underscorePos = allowedBaseLength; // 위치 조정
+                        }
+                        username = base.substring(0, underscorePos) + "_" + base.substring(underscorePos, allowedBaseLength);
+                    }
+                    username = username + numberStr;
+
+                    // email unique
+                    String email = username + "_" + i + "@example.com";
+
+                    ps.setString(1, username);
+                    ps.setString(2, email);
+                    ps.setString(3, null);
+                    ps.setString(4, null);
+                    ps.addBatch();
+
+                    if (i % BATCH_SIZE == 0 && i > 0) {
+                        ps.executeBatch();
+                        conn.commit();
+                        System.out.println("Inserted: " + i);
+                    }
+                }
+
+                ps.executeBatch();
+                conn.commit();
+
+                long end = System.currentTimeMillis();
+                System.out.println("Completed insert. Time = " + (end - start) / 1000 + "s");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- #37 

## 변경 사항

- 테스트용 User 더미데이터를 대량으로 Insert 하기 위한 `BulkUserInsert` 클래스를 작성하였습니다.
- `alex_park_001` 처럼 가능한 사실적인 Username을 생성하여 삽입하도록 구현하였습니다.
- 2백만 건 User 데이터를 삽입하고(삽입 약 8분 소요) 테스트를 진행하였습니다.

### 테스트 결과

- JPA에서 엔티티에 `@Column(unique = true)` 로 유니크 컬럼을 정의하면 자동으로 유니크 인덱스가 생성됩니다.
- `existsByUsername` 과 같은 Spring Data JPA의 메서드로 생성되는 쿼리는 다음과 같이 쿼리가 생성되어 실행됩니다.

```sql
select
        u1_0.user_id 
    from
        user u1_0 
    where
        u1_0.username=? 
    limit
        1
```

- 참고로 직접 exists SQL 쿼리를 짠다면 아래와 같이 할 수 있습니다:

```sql
select exists(
    select 1
    from user
    where username = 'rya_ncho447'
);
```

- `username`에 유니크 인덱스가 있으므로, 둘 다 인덱스를 통해 요소를 탐색합니다. `user_id` 데이터를 주고 받느냐의 차이는 있지만, 전자의 경우도 유니크 인덱스만 읽어서 `user_id`를 구할 수 있으므로 커버링 인덱스를 활용할 수 있어 매우 빠르게 처리됩니다. 큰 차이 없다고 판단할 수 있을 것 같습니다.
- 2백만 건 데이터를 삽입하고서 실제 속도 측정 결과:

<img width="542" height="106" alt="image" src="https://github.com/user-attachments/assets/abdecced-6e79-49f7-99ea-372a8cd62f25" />

<img width="783" height="537" alt="image" src="https://github.com/user-attachments/assets/1e779b44-ba97-4516-9e39-7f8ff320ce7a" />

- 2백만 건으로는 아직 인덱스만으로도 매우 빠르다고 볼 수 있겠습니다.

## 고려 및 주의 사항 (선택)

- TODO: 추후 1천만 건, 1억 건에서 차이를 테스트 해볼 것.
- 블룸 필터를 통한 최적화를 고민했으나, 1억 건에서도 비슷한 성능이라면 불필요한 최적화라고 판단될 것 같습니다.

## 추가 정보 (선택)
