### PR TITLE
[TEST #50]: ArchUnit 아키텍처 테스트 및 Spotless 포맷터 적용

### DIFF
--- a/server-v2/build.gradle
+++ b/server-v2/build.gradle
@@ -4,11 +4,24 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '4.0.3' apply false
 	id 'io.spring.dependency-management' version '1.1.7' apply false
+	id 'com.diffplug.spotless' version '8.3.0' apply false
 }
 
 subprojects {
 	apply plugin: 'java'
 	apply plugin: 'io.spring.dependency-management'
+	apply plugin: 'com.diffplug.spotless'
+
+	spotless {
+		java {
+			palantirJavaFormat()
+			importOrder('', 'static ')
+			removeUnusedImports()
+			formatAnnotations()
+			trimTrailingWhitespace()
+			endWithNewline()
+		}
+	}
 
 	group = 'com.plog'
 	version = '0.0.1-SNAPSHOT'
@@ -44,5 +57,9 @@ subprojects {
 
 	tasks.named('test') {
 		useJUnitPlatform()
+	}
+
+	tasks.named('check') {
+		dependsOn 'spotlessApply'
 	}
 }

--- a/server-v2/module/api/build.gradle
+++ b/server-v2/module/api/build.gradle
@@ -5,6 +5,9 @@ dependencies {
 	implementation project(':application')
 	implementation project(':infrastructure')
 	implementation project(':security')
+
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+	testImplementation 'com.tngtech.archunit:archunit:1.4.1'
 }

--- a/server-v2/module/api/src/main/java/com/plog/server/ServerApplication.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/ServerApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication(scanBasePackages = "com.plog")
 public class ServerApplication {
 
-	static void main(String[] args) {
-		SpringApplication.run(ServerApplication.class, args);
-	}
-
+    static void main(String[] args) {
+        SpringApplication.run(ServerApplication.class, args);
+    }
 }

--- a/server-v2/module/api/src/test/java/com/plog/server/ServerApplicationTests.java
+++ b/server-v2/module/api/src/test/java/com/plog/server/ServerApplicationTests.java
@@ -6,9 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ServerApplicationTests {
 
-	@Test
-	void contextLoads() {
-		// Spring ApplicationContext smoke test.
-	}
-
+    @Test
+    void contextLoads() {
+        // Spring ApplicationContext smoke test.
+    }
 }

--- a/server-v2/module/api/src/test/java/com/plog/server/architecture/ArchUnitTest.java
+++ b/server-v2/module/api/src/test/java/com/plog/server/architecture/ArchUnitTest.java
@@ -1,0 +1,26 @@
+package com.plog.server.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+class ArchUnitTest {
+
+    @Test
+    void domain_should_not_depend_on_springframework() {
+        JavaClasses importedClasses = new ClassFileImporter().importPackages("com.plog.server.domain");
+
+        ArchRule rule = noClasses()
+                .that()
+                .resideInAPackage("..domain..")
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage("org.springframework..")
+                .allowEmptyShould(true);
+
+        rule.check(importedClasses);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- closes #50

## 변경 사항

- ArchUnit을 활용하여 `domain` 모듈이 Spring Framework에 의존하지 않는지 검증하는 아키텍처 테스트 추가
- Spotless(Palantir Java Format) 포맷터를 전 모듈에 적용하고, 빌드 시 자동 포맷팅 되도록 설정

### domain 모듈에 `@Component`를 붙인 TestClass 작성

<img width="1286" height="599" alt="image" src="https://github.com/user-attachments/assets/80a6f34a-ba22-4fd8-b865-916c36b467fc" />

### ArchUnit 테스트 실패 확인

<img width="2708" height="949" alt="image" src="https://github.com/user-attachments/assets/80906f08-d19e-48d9-a9ab-81ab9d3407f8" />

너무 좋다.

## 고려 및 주의 사항 (선택)

- Spotless import 순서를 SonarQube/IntelliJ 관례(일반 import → static import)에 맞춰 `importOrder('', 'static ')` 설정
- `spotlessApply`를 `check` 태스크에 연결하여 빌드 시 자동 포맷 수정

## 추가 정보 (선택)