### PR TITLE
[REFACTOR #54]: .env를 사용한 환경 변수 기반 설정 방식 도입

### DIFF
--- a/server-v2/.env.example
+++ b/server-v2/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=db_name
+DB_USERNAME=db_username
+DB_PASSWORD=db_password
+JPA_DDL_AUTO=create

--- a/server-v2/.gitignore
+++ b/server-v2/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment ###
+.env

--- a/server-v2/docker-compose.yml
+++ b/server-v2/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  db:
+    image: postgres:18
+    container_name: plog-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: dev_db
+    volumes:
+      - plog-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  plog-postgres-data:

--- a/server-v2/module/api/src/main/resources/application.yaml
+++ b/server-v2/module/api/src/main/resources/application.yaml
@@ -1,3 +1,22 @@
 spring:
   application:
     name: server
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:none}
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+    open-in-view: false
+  config:
+    import: optional:file:.env[.properties]

--- a/server-v2/module/api/src/main/resources/application.yaml
+++ b/server-v2/module/api/src/main/resources/application.yaml
@@ -12,7 +12,7 @@ spring:
     baseline-on-migrate: true
   jpa:
     hibernate:
-      ddl-auto: ${JPA_DDL_AUTO:none}
+      ddl-auto: ${JPA_DDL_AUTO:validate}
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/server-v2/module/infrastructure/build.gradle
+++ b/server-v2/module/infrastructure/build.gradle
@@ -2,5 +2,7 @@ dependencies {
 	implementation project(':domain')
 	implementation project(':application')
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-database-postgresql'
+	runtimeOnly 'org.postgresql:postgresql'
 }


### PR DESCRIPTION
## 관련 이슈

- closes #54

## 변경 사항

- 프로필별 `.yml` 방식에서 단일 `.env` 파일 기반 환경 변수 관리 방식으로 전환
- MySQL → PostgreSQL 18 전환 및 DataSource 설정
- Flyway 마이그레이션 설정 추가 (`flyway-core`, `flyway-database-postgresql`)
- `docker-compose.yml` 추가 (PostgreSQL 18 컨테이너)
- `.env.example` 추가 (git 추적용 환경 변수 템플릿)
- `.gitignore`에 `.env` 제외 규칙 추가
- JPA `ddl-auto` 기본값을 `validate`로 설정 (Flyway 스키마 관리 + 엔티티 정합성 검증)

## 고려 및 주의 사항 (선택)

- `spring.config.import: optional:file:.env[.properties]`를 통해 `.env` 파일을 Spring 설정으로 직접 import
- Flyway가 스키마를 관리하고, `validate`가 엔티티-스키마 불일치를 앱 시작 시 감지
- `baseline-on-migrate: true`로 설정하여 기존 DB에도 Flyway 적용 가능