### PR TITLE
[FEATURE #56]: 공통 예외 처리 및 로깅 이벤트 시스템 구현

### DIFF
--- a/server-v2/module/api/build.gradle
+++ b/server-v2/module/api/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 	implementation project(':infrastructure')
 	implementation project(':security')
 
-	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.1'

--- a/server-v2/module/api/src/main/java/com/plog/server/support/exception/BusinessException.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/exception/BusinessException.java
@@ -1,0 +1,28 @@
+package com.plog.server.support.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorType errorType;
+
+    public BusinessException(ErrorType errorType) {
+        super(errorType.name());
+        this.errorType = errorType;
+    }
+
+    public BusinessException(String message, ErrorType errorType) {
+        super(message);
+        this.errorType = errorType;
+    }
+
+    public BusinessException(String message, Throwable cause, ErrorType errorType) {
+        super(message, cause);
+        this.errorType = errorType;
+    }
+
+    public BusinessException(Throwable cause, ErrorType errorType) {
+        super(cause);
+        this.errorType = errorType;
+    }
+}

--- a/server-v2/module/api/src/main/java/com/plog/server/support/exception/ErrorCode.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/exception/ErrorCode.java
@@ -1,0 +1,5 @@
+package com.plog.server.support.exception;
+
+public enum ErrorCode {
+    INTERNAL_SERVER_ERROR // DEFAULT_ERROR
+}

--- a/server-v2/module/api/src/main/java/com/plog/server/support/exception/ErrorType.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/exception/ErrorType.java
@@ -1,0 +1,18 @@
+package com.plog.server.support.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorType {
+    DEFAULT_ERROR(
+            HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR, "알 수 없는 에러가 발생하였습니다.", LogLevel.ERROR);
+
+    private final HttpStatus status;
+    private final ErrorCode code;
+    private final String message;
+    private final LogLevel logLevel;
+}

--- a/server-v2/module/api/src/main/java/com/plog/server/support/exception/GlobalExceptionHandler.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/exception/GlobalExceptionHandler.java
@@ -1,29 +1,41 @@
 package com.plog.server.support.exception;
 
+import com.plog.server.support.log.LogEvent;
 import com.plog.server.support.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+    private final ApplicationEventPublisher applicationEventPublisher;
+
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
-        var errorType = extractErrorType(e);
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(Exception e) {
+        var errorType = extractOrCreateErrorType(e);
+        publishLogEvent(errorType, e);
+
         ApiResponse<Void> response = ApiResponse.error(errorType.getCode(), errorType.getMessage());
 
         return ResponseEntity.status(errorType.getStatus()).body(response);
     }
 
-    private ErrorType extractErrorType(Exception e) {
+    private ErrorType extractOrCreateErrorType(Exception e) {
         ErrorType errorType;
-        if (e instanceof BusinessException) {
-            errorType = ((BusinessException) e).getErrorType();
+        if (e instanceof BusinessException businessException) {
+            errorType = businessException.getErrorType();
         } else {
             errorType = ErrorType.DEFAULT_ERROR;
         }
-        // TODO: 공통 Error Event 발행
         return errorType;
+    }
+
+    private void publishLogEvent(ErrorType errorType, Exception e) {
+        LogEvent logEvent = new LogEvent(errorType, e);
+        applicationEventPublisher.publishEvent(logEvent);
     }
 }

--- a/server-v2/module/api/src/main/java/com/plog/server/support/exception/GlobalExceptionHandler.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/exception/GlobalExceptionHandler.java
@@ -15,18 +15,18 @@ public class GlobalExceptionHandler {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleBusinessException(Exception e) {
-        var errorType = extractOrCreateErrorType(e);
-        publishLogEvent(errorType, e);
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception exception) {
+        var errorType = extractOrCreateErrorType(exception);
+        publishLogEvent(errorType, exception);
 
         ApiResponse<Void> response = ApiResponse.error(errorType.getCode(), errorType.getMessage());
 
         return ResponseEntity.status(errorType.getStatus()).body(response);
     }
 
-    private ErrorType extractOrCreateErrorType(Exception e) {
+    private ErrorType extractOrCreateErrorType(Exception exception) {
         ErrorType errorType;
-        if (e instanceof BusinessException businessException) {
+        if (exception instanceof BusinessException businessException) {
             errorType = businessException.getErrorType();
         } else {
             errorType = ErrorType.DEFAULT_ERROR;

--- a/server-v2/module/api/src/main/java/com/plog/server/support/exception/GlobalExceptionHandler.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.plog.server.support.exception;
+
+import com.plog.server.support.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        var errorType = extractErrorType(e);
+        ApiResponse<Void> response = ApiResponse.error(errorType.getCode(), errorType.getMessage());
+
+        return ResponseEntity.status(errorType.getStatus()).body(response);
+    }
+
+    private ErrorType extractErrorType(Exception e) {
+        ErrorType errorType;
+        if (e instanceof BusinessException) {
+            errorType = ((BusinessException) e).getErrorType();
+        } else {
+            errorType = ErrorType.DEFAULT_ERROR;
+        }
+        // TODO: 공통 Error Event 발행
+        return errorType;
+    }
+}

--- a/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEvent.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEvent.java
@@ -1,0 +1,9 @@
+package com.plog.server.support.log;
+
+import com.plog.server.support.exception.ErrorType;
+
+public record LogEvent(
+        ErrorType errorType,
+        Exception e
+) {
+}

--- a/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEvent.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEvent.java
@@ -2,8 +2,4 @@ package com.plog.server.support.log;
 
 import com.plog.server.support.exception.ErrorType;
 
-public record LogEvent(
-        ErrorType errorType,
-        Exception exception
-) {
-}
+public record LogEvent(ErrorType errorType, Exception exception) {}

--- a/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEvent.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEvent.java
@@ -4,6 +4,6 @@ import com.plog.server.support.exception.ErrorType;
 
 public record LogEvent(
         ErrorType errorType,
-        Exception e
+        Exception exception
 ) {
 }

--- a/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEventHandler.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEventHandler.java
@@ -1,0 +1,5 @@
+package com.plog.server.support.log;
+
+public interface LogEventHandler {
+    void handleLogEvent(LogEvent logEvent);
+}

--- a/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEventListener.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEventListener.java
@@ -1,0 +1,20 @@
+package com.plog.server.support.log;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class LogEventListener {
+    private final List<LogEventHandler> handlers;
+
+    @EventListener
+    public void onLogEvent(LogEvent logEvent) {
+        for (LogEventHandler handler : handlers) {
+            handler.handleLogEvent(logEvent);
+        }
+    }
+}

--- a/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEventListener.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEventListener.java
@@ -1,11 +1,10 @@
 package com.plog.server.support.log;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEventListener.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/log/LogEventListener.java
@@ -1,6 +1,7 @@
 package com.plog.server.support.log;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -8,13 +9,18 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class LogEventListener {
     private final List<LogEventHandler> handlers;
 
     @EventListener
     public void onLogEvent(LogEvent logEvent) {
         for (LogEventHandler handler : handlers) {
-            handler.handleLogEvent(logEvent);
+            try {
+                handler.handleLogEvent(logEvent);
+            } catch (Exception e) {
+                log.error("Error while handling log event", e);
+            }
         }
     }
 }

--- a/server-v2/module/api/src/main/java/com/plog/server/support/log/handler/Slf4jLogEventHandler.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/log/handler/Slf4jLogEventHandler.java
@@ -13,11 +13,11 @@ public class Slf4jLogEventHandler implements LogEventHandler {
     public void handleLogEvent(LogEvent logEvent) {
         String message = "Exception: ";
         switch (logEvent.errorType().getLogLevel()) {
-            case TRACE -> log.trace(message, logEvent.e());
-            case DEBUG -> log.debug(message, logEvent.e());
-            case INFO -> log.info(message, logEvent.e());
-            case WARN -> log.warn(message, logEvent.e());
-            case ERROR -> log.error(message, logEvent.e());
+            case TRACE -> log.trace(message, logEvent.exception());
+            case DEBUG -> log.debug(message, logEvent.exception());
+            case INFO -> log.info(message, logEvent.exception());
+            case WARN -> log.warn(message, logEvent.exception());
+            case ERROR -> log.error(message, logEvent.exception());
             default -> throw new IllegalStateException("Unexpected value: " + logEvent.errorType().getLogLevel());
         }
     }

--- a/server-v2/module/api/src/main/java/com/plog/server/support/log/handler/Slf4jLogEventHandler.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/log/handler/Slf4jLogEventHandler.java
@@ -1,0 +1,24 @@
+package com.plog.server.support.log.handler;
+
+import com.plog.server.support.log.LogEvent;
+import com.plog.server.support.log.LogEventHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class Slf4jLogEventHandler implements LogEventHandler {
+
+    @Override
+    public void handleLogEvent(LogEvent logEvent) {
+        String message = "Exception: ";
+        switch (logEvent.errorType().getLogLevel()) {
+            case TRACE -> log.trace(message, logEvent.e());
+            case DEBUG -> log.debug(message, logEvent.e());
+            case INFO -> log.info(message, logEvent.e());
+            case WARN -> log.warn(message, logEvent.e());
+            case ERROR -> log.error(message, logEvent.e());
+            default -> throw new IllegalStateException("Unexpected value: " + logEvent.errorType().getLogLevel());
+        }
+    }
+}

--- a/server-v2/module/api/src/main/java/com/plog/server/support/log/handler/Slf4jLogEventHandler.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/log/handler/Slf4jLogEventHandler.java
@@ -17,8 +17,10 @@ public class Slf4jLogEventHandler implements LogEventHandler {
             case DEBUG -> log.debug(message, logEvent.exception());
             case INFO -> log.info(message, logEvent.exception());
             case WARN -> log.warn(message, logEvent.exception());
-            case ERROR -> log.error(message, logEvent.exception());
-            default -> throw new IllegalStateException("Unexpected value: " + logEvent.errorType().getLogLevel());
+            case ERROR, FATAL -> log.error(message, logEvent.exception());
+            default ->
+                throw new IllegalStateException(
+                        "Unexpected value: " + logEvent.errorType().getLogLevel());
         }
     }
 }

--- a/server-v2/module/api/src/main/java/com/plog/server/support/response/ApiResponse.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/response/ApiResponse.java
@@ -1,0 +1,9 @@
+package com.plog.server.support.response;
+
+import com.plog.server.support.exception.ErrorCode;
+
+public record ApiResponse<T>(boolean success, T data, ErrorMessage error) {
+    public static ApiResponse<Void> error(ErrorCode code, String message) {
+        return new ApiResponse<>(false, null, new ErrorMessage(code, message));
+    }
+}

--- a/server-v2/module/api/src/main/java/com/plog/server/support/response/ErrorMessage.java
+++ b/server-v2/module/api/src/main/java/com/plog/server/support/response/ErrorMessage.java
@@ -1,0 +1,5 @@
+package com.plog.server.support.response;
+
+import com.plog.server.support.exception.ErrorCode;
+
+public record ErrorMessage(ErrorCode code, String message) {}

--- a/server-v2/module/api/src/main/resources/application.yaml
+++ b/server-v2/module/api/src/main/resources/application.yaml
@@ -15,7 +15,6 @@ spring:
       ddl-auto: ${JPA_DDL_AUTO:validate}
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
     open-in-view: false
   config:

--- a/server-v2/module/api/src/test/java/com/plog/server/support/exception/GlobalExceptionHandlerTest.java
+++ b/server-v2/module/api/src/test/java/com/plog/server/support/exception/GlobalExceptionHandlerTest.java
@@ -12,8 +12,8 @@ import static org.mockito.Mockito.*;
 
 class GlobalExceptionHandlerTest {
 
-    ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
-    GlobalExceptionHandler handler = new GlobalExceptionHandler(publisher);
+    ApplicationEventPublisher applicationEventPublisher = mock(ApplicationEventPublisher.class);
+    GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler(applicationEventPublisher);
 
     @Test
     @DisplayName("Exception 발생 시 반환 body의 타입은 ApiResponse이어야 한다.")
@@ -22,7 +22,7 @@ class GlobalExceptionHandlerTest {
         var exception = new Exception();
 
         // when
-        var response = handler.handleException(exception);
+        var response = globalExceptionHandler.handleException(exception);
 
         // then
         assertThat(response.getBody()).isNotNull();
@@ -36,7 +36,7 @@ class GlobalExceptionHandlerTest {
         var exception = new Exception();
 
         // when
-        var response = handler.handleException(exception);
+        var response = globalExceptionHandler.handleException(exception);
 
         // then
         assertThat(response.getBody()).isNotNull();
@@ -51,7 +51,7 @@ class GlobalExceptionHandlerTest {
         var exception = new Exception();
 
         // when
-        var response = handler.handleException(exception);
+        var response = globalExceptionHandler.handleException(exception);
 
         // then
         assertThat(response.getBody()).isNotNull();
@@ -66,7 +66,7 @@ class GlobalExceptionHandlerTest {
         var exception = new BusinessException(ErrorType.DEFAULT_ERROR);
 
         // when
-        var response = handler.handleException(exception);
+        var response = globalExceptionHandler.handleException(exception);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(exception.getErrorType().getStatus());
@@ -79,11 +79,12 @@ class GlobalExceptionHandlerTest {
         var exception = new BusinessException(ErrorType.DEFAULT_ERROR);
 
         // when
-        var response = handler.handleException(exception);
+        var response = globalExceptionHandler.handleException(exception);
 
         // then
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().error().code()).isEqualTo(exception.getErrorType().getCode());
+        assertThat(response.getBody().error().code())
+                .isEqualTo(exception.getErrorType().getCode());
     }
 
     @Test
@@ -93,9 +94,9 @@ class GlobalExceptionHandlerTest {
         var exception = new Exception();
 
         // when
-        handler.handleException(exception);
+        globalExceptionHandler.handleException(exception);
 
         // then
-        then(publisher).should().publishEvent(any(LogEvent.class));
+        then(applicationEventPublisher).should().publishEvent(any(LogEvent.class));
     }
 }

--- a/server-v2/module/api/src/test/java/com/plog/server/support/exception/GlobalExceptionHandlerTest.java
+++ b/server-v2/module/api/src/test/java/com/plog/server/support/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,101 @@
+package com.plog.server.support.exception;
+
+import com.plog.server.support.log.LogEvent;
+import com.plog.server.support.response.ApiResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+class GlobalExceptionHandlerTest {
+
+    ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+    GlobalExceptionHandler handler = new GlobalExceptionHandler(publisher);
+
+    @Test
+    @DisplayName("Exception 발생 시 반환 body의 타입은 ApiResponse이어야 한다.")
+    void shouldReturnApiResponseWhenExceptionIsThrown() {
+        // given
+        var exception = new Exception();
+
+        // when
+        var response = handler.handleException(exception);
+
+        // then
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).isInstanceOf(ApiResponse.class);
+    }
+
+    @Test
+    @DisplayName("Exception 발생 시 ApiResponse의 success는 false여야 한다.")
+    void shouldSetSuccessFalseWhenExceptionIsThrown() {
+        // given
+        var exception = new Exception();
+
+        // when
+        var response = handler.handleException(exception);
+
+        // then
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).isInstanceOf(ApiResponse.class);
+        assertThat(response.getBody().success()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Exception 발생 시 ApiResponse의 error는 null이어서는 안 된다.")
+    void shouldHaveNonNullErrorWhenExceptionIsThrown() {
+        // given
+        var exception = new Exception();
+
+        // when
+        var response = handler.handleException(exception);
+
+        // then
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).isInstanceOf(ApiResponse.class);
+        assertThat(response.getBody().error()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("BusinessException 발생 시 응답은 해당 ErrorType과 같은 HTTP 상태 코드를 포함해야 한다.")
+    void shouldReturnHttpStatusMatchingErrorTypeWhenBusinessExceptionThrown() {
+        // given
+        var exception = new BusinessException(ErrorType.DEFAULT_ERROR);
+
+        // when
+        var response = handler.handleException(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(exception.getErrorType().getStatus());
+    }
+
+    @Test
+    @DisplayName("BusinessException 발생 시 ErrorMessage는 해당 ErrorType의 ErrorCode를 포함해야 한다.")
+    void shouldIncludeErrorCodeWhenBusinessExceptionThrown() {
+        // given
+        var exception = new BusinessException(ErrorType.DEFAULT_ERROR);
+
+        // when
+        var response = handler.handleException(exception);
+
+        // then
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().error().code()).isEqualTo(exception.getErrorType().getCode());
+    }
+
+    @Test
+    @DisplayName("Exception 발생 시 LogEvent를 발행해야 한다.")
+    void shouldPublishLogEventWhenExceptionIsThrown() {
+        // given
+        var exception = new Exception();
+
+        // when
+        handler.handleException(exception);
+
+        // then
+        then(publisher).should().publishEvent(any(LogEvent.class));
+    }
+}

--- a/server-v2/module/api/src/test/java/com/plog/server/support/log/LogEventListenerTest.java
+++ b/server-v2/module/api/src/test/java/com/plog/server/support/log/LogEventListenerTest.java
@@ -1,0 +1,51 @@
+package com.plog.server.support.log;
+
+import com.plog.server.support.exception.ErrorType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+class LogEventListenerTest {
+
+    private final LogEventHandler failingHandler = mock(LogEventHandler.class);
+    private final LogEventHandler normalHandler = mock(LogEventHandler.class);
+    private final LogEventListener logEventListener = new LogEventListener(List.of(failingHandler, normalHandler));
+
+    @Test
+    @DisplayName("LogEvent 발생 시 모든 logEventHandler에 이를 위임해야 한다.")
+    void shouldDelegateLogEventToAllHandlers() {
+        // given
+        var logEvent = new LogEvent(ErrorType.DEFAULT_ERROR, new Exception());
+
+        // when
+        logEventListener.onLogEvent(logEvent);
+
+        // then
+        then(normalHandler).should(times(1)).handleLogEvent(logEvent);
+        then(failingHandler).should(times(1)).handleLogEvent(logEvent);
+        then(failingHandler).shouldHaveNoMoreInteractions();
+        then(normalHandler).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("특정 handler가 예외를 던져도 다른 handler는 계속 실행되어야 한다.")
+    void shouldContinueHandlingWhenHandlerThrowsException() {
+        // given
+        var logEvent = new LogEvent(ErrorType.DEFAULT_ERROR, new Exception());
+        willThrow(new RuntimeException()).given(failingHandler).handleLogEvent(logEvent);
+
+        // when & then
+        assertThatCode(() -> logEventListener.onLogEvent(logEvent)).doesNotThrowAnyException();
+
+        then(failingHandler).should(times(1)).handleLogEvent(logEvent);
+        then(normalHandler).should(times(1)).handleLogEvent(logEvent);
+        then(failingHandler).shouldHaveNoMoreInteractions();
+        then(normalHandler).shouldHaveNoMoreInteractions();
+    }
+}

--- a/server-v2/module/api/src/test/java/com/plog/server/support/log/handler/Slf4jLogEventHandlerTest.java
+++ b/server-v2/module/api/src/test/java/com/plog/server/support/log/handler/Slf4jLogEventHandlerTest.java
@@ -1,0 +1,66 @@
+package com.plog.server.support.log.handler;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.plog.server.support.exception.ErrorType;
+import com.plog.server.support.log.LogEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.logging.LogLevel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Slf4jLogEventHandlerTest {
+
+    private final Slf4jLogEventHandler slf4jLogEventHandler = new Slf4jLogEventHandler();
+    private final Logger logger = (Logger) LoggerFactory.getLogger(Slf4jLogEventHandler.class);
+    private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+        appender.stop();
+    }
+
+    @ParameterizedTest
+    @EnumSource(ErrorType.class)
+    @DisplayName("ErrorType의 로그 레벨에 맞는 로깅이 이루어져야 한다.")
+    void shouldLogAtExpectedLevelForGivenErrorType(ErrorType errorType) {
+        // given
+        appender.start();
+        logger.addAppender(appender);
+
+        var logEvent = new LogEvent(errorType, new RuntimeException());
+
+        // when
+        slf4jLogEventHandler.handleLogEvent(logEvent);
+
+        // then
+        if (errorType.getLogLevel() == LogLevel.OFF) {
+            assertThat(appender.list).isEmpty();
+            return;
+        }
+
+        assertThat(appender.list).hasSize(1);
+
+        ILoggingEvent loggingEvent = appender.list.getFirst();
+
+        assertThat(loggingEvent.getLevel()).isEqualTo(toLogbackLevel(errorType.getLogLevel()));
+    }
+
+    private Level toLogbackLevel(LogLevel logLevel) {
+        return switch (logLevel) {
+            case TRACE -> Level.TRACE;
+            case DEBUG -> Level.DEBUG;
+            case INFO -> Level.INFO;
+            case WARN -> Level.WARN;
+            case ERROR, FATAL -> Level.ERROR;
+            case OFF -> null;
+        };
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- closes #56

## 변경 사항

공통 예외 처리와 로깅을 위한 support 패키지를 구현했습니다.

`BusinessException`, `ErrorCode`, `ErrorType`으로 예외 체계를 잡고, `GlobalExceptionHandler`(컨트롤러 어드바이스)에서 모든 Exception을 받는 하나의 핸들러 메서드만 두었습니다. `BusinessException`이면 해당 `ErrorType`을 쓰고, 아니면 `DEFAULT_ERROR`로 처리합니다. 응답은 `ApiResponse<T>`, `ErrorMessage` record로 통일했습니다.

`GlobalExceptionHandler`에서 로깅까지 하게 만들기 싫어서, 예외 처리 부분과 로깅 부분을 `ApplicationEventPublisher`를 통해 분리했습니다. `GlobalExceptionHandler`는 이제 직접 로거를 호출하지 않고 `LogEvent`만 발행합니다. `LogEvent`는 `LogEventListener`가 받아서 애플리케이션 내 `LogEventHandler`들을 돌려가며 이벤트 처리를 위임합니다. 기본 구현체로 `Slf4jLogEventHandler`를 두었고, `ErrorType`의 로그 레벨에 따라 SLF4J로 로깅합니다.

이렇게 할 경우, 별도의 RDB, NoSQL 로깅 등 로깅 관련 비즈니스 로직이 늘어날 경우 그에 해당하는 `LogEventHandler`를 추가로 구현함으로써 해결할 수 있습니다(실제로 최근 현업에서 비슷한 요구사항이 있었는데, 해당 패턴으로 상당히 깔끔하게 추상화할 수 있었다고 나름 평가합니다ㅎㅎ). `AutoConfiguration`을 활용하면, 환경에 따라 핸들러를 껐다 켰다도 가능합니다(로컬/CI 환경에서 불필요하게 비동기 외부 로깅에 의한 Exception이 잔뜩 찍히는 걸 방지할 수 있습니다...!).

`LogEventListener`에서 특정 핸들러가 예외를 던져도 나머지 핸들러가 계속 실행되도록 try-catch를 추가했습니다. 핸들러가 늘어났을 때 하나의 실패가 전체 로깅을 중단시키지 않도록 하기 위함입니다.

그 외에 `build.gradle`에서 `spring-boot-starter-webmvc`를 `spring-boot-starter-web`으로 바꾸고, `application.yaml`에서 하드코딩되어 있던 `hibernate.dialect` (PostgreSQLDialect)를 제거하여 Hibernate 자동 감지에 맡겼습니다.

### 변경 파일 요약

**예외 처리**
- `BusinessException`: 비즈니스 로직 전용 커스텀 예외 클래스
- `ErrorCode`: 오류 코드 enum
- `ErrorType`: HTTP 상태, 오류 코드, 메시지, 로그 레벨을 묶는 enum
- `GlobalExceptionHandler`: `@RestControllerAdvice` 기반 전역 예외 핸들러

**API 응답**
- `ApiResponse<T>`: 공통 응답 record
- `ErrorMessage`: 에러 코드/메시지 record

**로깅 이벤트**
- `LogEvent`: 이벤트 record
- `LogEventHandler`: 처리 인터페이스
- `LogEventListener`: 이벤트 리스너 → 핸들러 위임 (핸들러 예외 시에도 나머지 계속 실행)
- `Slf4jLogEventHandler`: SLF4J 기본 구현체

**테스트**
- `GlobalExceptionHandlerTest`: 응답 구조, 상태 코드, ErrorCode, LogEvent 발행 검증
- `LogEventListenerTest`: 핸들러 위임 및 핸들러 예외 시 계속 실행 검증
- `Slf4jLogEventHandlerTest`: ErrorType별 로그 레벨 매핑 검증

## 고려 및 주의 사항 (선택)

- 현재 `BusinessException`이 아닌 일반 `Exception`은 `DEFAULT_ERROR`로 처리됩니다. 일반 예외를 `BusinessException`으로 아예 변환시키는 게 나을지는 추후 논의가 필요합니다.
- 현재 모든 Exception을 받아서 BASE_EXCEPTION으로 변환해 처리하므로, 기본적인 예외들에 대한 핸들링이 추가되어야 합니다.
- `LogEvent`, `LogEventListener`, `LogEventHandler` 등의 네이밍은 개선의 여지가 있습니다. (`LogEventListener`와 `LogEventHandler` 가 나뉘어져 있는 걸 보고 다른 사람들이 설계 의도를 직관적으로 이해할 수 있을까요...?)

## 추가 정보 (선택)

- **TODO**: 각 HTTP 요청별 고유 스레드 정보를 함께 로깅/트레이싱하기 위한 MDC 로직 추가가 `log` 모듈에 필요합니다.